### PR TITLE
Removed element type config key

### DIFF
--- a/elementapi/controllers/ElementApiController.php
+++ b/elementapi/controllers/ElementApiController.php
@@ -77,10 +77,23 @@ class ElementApiController extends BaseController
 			throw new Exception('Element API configs must specify the elementType.');
 		}
 
-		/** @var ElementCriteriaModel $criteria */
-		$criteria = craft()->elements->getCriteria($config['elementType'], [
-			'limit' => null
-		]);
+		switch($config['resource']) {
+            case "element":
+                /** @var ElementCriteriaModel $criteria */
+                $criteria = craft()->elements->getCriteria($config['resourceType'], [
+                    'limit' => null
+                ]);
+
+                break;
+
+            case "section":
+                /** @var SectionModel $criteria */
+                $criteria = craft()->sections->getSectionsByType($config['resourceType'], [
+                    'limit' => null
+                ]);
+
+                break;
+        }
 
 		if (!empty($config['criteria']))
 		{

--- a/releases.json
+++ b/releases.json
@@ -65,7 +65,7 @@
     "downloadUrl": "https://github.com/craftcms/element-api/archive/1.6.0.zip",
     "date": "2017-05-25T06:00:00-08:00",
     "notes": [
-      "Added the `include` and `exclude` endpoint config settings."
+      "[Added] Added the `include` and `exclude` endpoint config settings."
     ]
   }
 ]


### PR DESCRIPTION
The Element API plugin v1 only support an Element Type. I've had issues where I wanted an endpoint that shows the sections I have by type. I've added a switch inside the controller and two new keys: 

- resource (can be "element" or "section")
- resourceType (can be any sort of type related to the resource requested)