### PR TITLE
Correct documentation URL

### DIFF
--- a/elementapi/ElementApiPlugin.php
+++ b/elementapi/ElementApiPlugin.php
@@ -56,7 +56,7 @@ class ElementApiPlugin extends BasePlugin
 	 */
 	public function getDocumentationUrl()
 	{
-		return $this->getPluginUrl().'/blob/v1/README.md';
+		return $this->getPluginUrl().'/README.md';
 	}
 
 	/**


### PR DESCRIPTION
https://github.com/craftcms/element-api/tree/v1/blob/v1/README.md resulted in a 404, changing it to https://github.com/craftcms/element-api/tree/v1/README.md will automatically redirect you to the right page.