### PR TITLE
Update the JSON Feed V1 implementation to support variable resource key.

### DIFF
--- a/src/JsonFeedV1Serializer.php
+++ b/src/JsonFeedV1Serializer.php
@@ -19,7 +19,8 @@ class JsonFeedV1Serializer extends ArraySerializer
      */
     public function collection($resourceKey, array $data)
     {
-        return ['items' => $data];
+        $resourceKey = $resourceKey ? $resourceKey : 'items';
+        return [$resourceKey => $data];
     }
 
     /**


### PR DESCRIPTION
Current version doesn't actually use the passed resource key.