### PR TITLE
Add cache to ElementResource to be able to set it as a default

### DIFF
--- a/src/resources/ElementResource.php
+++ b/src/resources/ElementResource.php
@@ -75,6 +75,11 @@ class ElementResource extends BaseObject implements ResourceAdapterInterface
      */
     public $meta;
 
+    /**
+     * @var bool|int|string Whether the output should be cached, and for how long.
+     */
+    public $cache = false;
+
     // Public Methods
     // =========================================================================
 


### PR DESCRIPTION
The plugin throws an error if cache is in the defaults section of the element-api.php file. 