### PR TITLE
Update documentation example to avoid looping through element query directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ Here are a few endpoint examples, and what their response would look like.
         'transformer' => function(craft\elements\Entry $entry) {
             // Create an array of all the photo URLs
             $photos = [];
-            foreach ($entry->photos as $photo) {
+            foreach ($entry->photos->all() as $photo) {
                 $photos[] = $photo->url;
             }
 


### PR DESCRIPTION
Current example generates error

> Looping through element queries directly has been deprecated. Use the all() function to fetch the query results before looping over them.