### PR TITLE
Change text from the Craft 2 craft/config to Craft 3 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To install the plugin, follow these instructions.
 
 ## Setup
 
-To define your API endpoints, create a new `element-api.php` file within your craft/config/ folder. This file should return an array with an `endpoints` key, which defines your site’s API endpoints. Within the `endpoints` array, keys are URL patterns, and values are endpoint configurations.
+To define your API endpoints, create a new `element-api.php` file within your config folder. This file should return an array with an `endpoints` key, which defines your site’s API endpoints. Within the `endpoints` array, keys are URL patterns, and values are endpoint configurations.
 
 ```php
 <?php


### PR DESCRIPTION
In this PR, the config path stated in the README is changed from the Craft 2 `craft/config` to Craft 3 `config`.