### PR TITLE
Fix caching of endpoints

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -93,7 +93,7 @@ class DefaultController extends Controller
             $cache = ArrayHelper::remove($config, 'cache', false);
 
             if ($cache) {
-                $cacheKey = 'elementapi:'.$siteId.':'.$request->getPathInfo().':'.$request->getQueryStringWithoutPath();
+                $cacheKey = 'elementapi:'.$siteId.':'.$request->getPathInfo(true).':'.$request->getQueryStringWithoutPath();
                 $cacheService = Craft::$app->getCache();
 
                 if (($cachedContent = $cacheService->get($cacheKey)) !== false) {


### PR DESCRIPTION
When manually executing Element API endpoint queries via Craft::$app->request->setPathInfo($endpoint); Craft::$app->runAction('element-api', ['pattern'=>$endpoint]), Element API caching is not working correctly as getPathInfo() does not return the updated path. Fixed by changing to getPathInfo(true).