### PR TITLE
Allow defaults setting to be set to a closure

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -63,7 +63,7 @@ class Plugin extends \craft\base\Plugin
             return $this->_defaultResourceAdapterConfig;
         }
 
-        return $this->_defaultResourceAdapterConfig = $this->getSettings()->defaults;
+        return $this->_defaultResourceAdapterConfig = $this->getSettings()->getDefaults();
     }
 
     /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -12,8 +12,11 @@ use craft\base\Model;
  */
 class Settings extends Model
 {
+    // Properties
+    // =========================================================================
+
     /**
-     * @var array The default endpoint configuration.
+     * @var callable|array The default endpoint configuration.
      */
     public $defaults = [];
 
@@ -21,4 +24,17 @@ class Settings extends Model
      * @var array The endpoint configurations.
      */
     public $endpoints = [];
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * Returns the default endpoint configuration.
+     *
+     * @return array The default endpoint configuration.
+     */
+    public function getDefaults()
+    {
+        return is_callable($this->defaults) ? call_user_func($this->defaults) : $this->defaults;
+    }
 }


### PR DESCRIPTION
When defining `defaults` I need to make use of Craft’s request service, and without having it in a callable it’s throwing errors on console requests.

```php
return [
    'defaults' => function() {
        $request = Craft::$app->getRequest();
        return [
            'paginate' => false,
            'includes' => (array)$request->getQueryParam('include'),
            'excludes' => (array)$request->getQueryParam('exclude'),
        ];
    },
    'endpoints' => [],
];
```