### PR TITLE
add tag dependency when setting cache

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -23,6 +23,7 @@ use League\Fractal\Serializer\JsonApiSerializer;
 use League\Fractal\Serializer\SerializerAbstract;
 use ReflectionFunction;
 use yii\base\InvalidConfigException;
+use yii\caching\TagDependency;
 use yii\web\HttpException;
 use yii\web\JsonResponseFormatter;
 use yii\web\NotFoundHttpException;
@@ -38,6 +39,8 @@ class DefaultController extends Controller
 {
     // Constants
     // =========================================================================
+
+    const CACHE_TAG = 'elementapi';
 
     /**
      * @event DataEvent The event that is triggered before sending the response data
@@ -202,7 +205,7 @@ class DefaultController extends Controller
                 $expire = null;
             }
             /** @noinspection PhpUndefinedVariableInspection */
-            $cacheService->set($cacheKey, $response->content, $expire);
+            $cacheService->set($cacheKey, $response->content, $expire, new TagDependency(['tags' => self::CACHE_TAG]));
         }
 
         // Don't double-encode the data


### PR DESCRIPTION
Replicated from craftcms GraphQL implementation to make it possible to clear the element-api cache without resorting to `cache->flush()`.

We'd like to programmatically clear the element-api cache when entries are saved using TagDependency.

For example:

```php
TagDependency::invalidate(Craft::$app->getCache(), 'elementapi');
```