### PR TITLE
Only cache response when statusCode is success

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -195,7 +195,7 @@ class DefaultController extends Controller
         $response->format = Response::FORMAT_RAW;
 
         // Cache it?
-        if ($cache) {
+        if ($cache && $statusCode===200) {
             if ($cache !== true) {
                 $expire = ConfigHelper::durationInSeconds($cache);
             } else {


### PR DESCRIPTION
### Description
Don't cache error responses only success 


### Related issues
https://github.com/craftcms/element-api/issues/130 
