### PR TITLE
log errors thrown in default action - Fixes #117

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -171,6 +171,12 @@ class DefaultController extends Controller
             ];
             $statusCode = $e instanceof HttpException ? $e->statusCode : 500;
             $statusText = $e->getMessage();
+
+            // log error
+            Craft::error($e->getMessage(), __METHOD__);
+            /** @var \yii\base\ErrorHandler $errorHandler */
+            $errorHandler = $this->getErrorHandler();
+            $errorHandler->logException($e);
         }
 
         // Create a JSON response formatter with custom options


### PR DESCRIPTION
### Description
Logs errors thrown in the element API's default controller action using `Craft::error` and `\yii\base\ErrorHandler::logException()`.

### Related issues
#117 

