### PR TITLE
fix: Do not use the cache when preview mode is enabled.

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -93,7 +93,7 @@ class DefaultController extends Controller
             }
 
             // Before anything else, check the cache
-            $cache = ArrayHelper::remove($config, 'cache', true) && !Craft::$app->request->getToken();
+            $cache = ArrayHelper::remove($config, 'cache', true) && !Craft::$app->request->isPreview;
 
             if ($cache) {
                 $cacheKey = 'elementapi:'.$siteId.':'.$request->getPathInfo().':'.$request->getQueryStringWithoutPath();

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -93,7 +93,7 @@ class DefaultController extends Controller
             }
 
             // Before anything else, check the cache
-            $cache = ArrayHelper::remove($config, 'cache', true);
+            $cache = ArrayHelper::remove($config, 'cache', true) && !Craft::$app->request->getToken();
 
             if ($cache) {
                 $cacheKey = 'elementapi:'.$siteId.':'.$request->getPathInfo().':'.$request->getQueryStringWithoutPath();


### PR DESCRIPTION
### Description
When preview mode is enabled in the request do not try to fetch from or write to the cache,
this fixes possibly fetching stale content or writing draft content to the cache.

Note: I'm using `getToken()` instead of `isPreview`, because `isPreview` returns false when using the `X-Craft-Token` header.

### Related issues
Fixes #143 
