### PR TITLE
Allow to define a custom cache key

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -2,6 +2,7 @@
 
 namespace craft\elementapi;
 
+use Craft;
 use craft\base\Model;
 
 /**
@@ -31,5 +32,22 @@ class Settings extends Model
     public function getDefaults()
     {
         return is_callable($this->defaults) ? call_user_func($this->defaults) : $this->defaults;
+    }
+
+    /**
+     * Returns the default data cache key that should be used for endpoint responses.
+     *
+     * @return string The default data cache key.
+     */
+    public static function cacheKey(): string
+    {
+        $request = Craft::$app->getRequest();
+
+        return implode(':', [
+            'elementapi',
+            Craft::$app->getSites()->getCurrentSite()->id,
+            $request->getPathInfo(),
+            $request->getQueryStringWithoutPath(),
+        ]);
     }
 }

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -13,6 +13,7 @@ use Craft;
 use craft\elementapi\DataEvent;
 use craft\elementapi\JsonFeedV1Serializer;
 use craft\elementapi\Plugin;
+use craft\elementapi\Settings;
 use craft\helpers\ArrayHelper;
 use craft\helpers\ConfigHelper;
 use craft\helpers\StringHelper;
@@ -70,8 +71,6 @@ class DefaultController extends Controller
         try {
             $plugin = Plugin::getInstance();
             $config = $plugin->getEndpoint($pattern);
-            $request = Craft::$app->getRequest();
-            $siteId = Craft::$app->getSites()->getCurrentSite()->id;
 
             if (is_callable($config)) {
                 $params = Craft::$app->getUrlManager()->getRouteParams();
@@ -88,7 +87,7 @@ class DefaultController extends Controller
             $cacheKey = ArrayHelper::remove($config, 'cacheKey', null);
 
             if ($cache) {
-                $cacheKey = $cacheKey ?? 'elementapi:'.$siteId.':'.$request->getPathInfo().':'.$request->getQueryStringWithoutPath();
+                $cacheKey = $cacheKey ?? Settings::cacheKey();
                 $cacheService = Craft::$app->getCache();
 
                 if (($cachedContent = $cacheService->get($cacheKey)) !== false) {

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -85,9 +85,10 @@ class DefaultController extends Controller
 
             // Before anything else, check the cache
             $cache = ArrayHelper::remove($config, 'cache', true);
+            $cacheKey = ArrayHelper::remove($config, 'cacheKey', null);
 
             if ($cache) {
-                $cacheKey = 'elementapi:'.$siteId.':'.$request->getPathInfo().':'.$request->getQueryStringWithoutPath();
+                $cacheKey = $cacheKey ?? 'elementapi:'.$siteId.':'.$request->getPathInfo().':'.$request->getQueryStringWithoutPath();
                 $cacheService = Craft::$app->getCache();
 
                 if (($cachedContent = $cacheService->get($cacheKey)) !== false) {


### PR DESCRIPTION
### Description

The parts the plugin’s default cache key is composed of isn’t sufficient for us, as we’re serving different responses depending on a header in the request.

https://github.com/craftcms/element-api/blob/ed112a55802c005b2d80810bd85e87a91d561972/src/controllers/DefaultController.php#L90

This PR allows to set a custom cache key per endpoint or using the default config setting.

For our use case we’d use a configuration like this.

```php
return [
    'defaults' => function() {
        $request = Craft::$app->getRequest();
        
        return [
            'cacheKey' => implode(':', [
                'elementapi',
                Craft::$app->getSites()->getCurrentSite()->id,
                $request->getPathInfo(),
                $request->getQueryStringWithoutPath(),
                $request->getHeaders()->get('X-API-Token'),
            ]),
        ];
    },
    'endpoints' => [],
];
```