### PR TITLE
Always remove cacheKey from config

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -100,15 +100,16 @@ class DefaultController extends Controller
                 ArrayHelper::remove($config, 'cache', true) &&
                 !($this->request->getIsPreview() || $this->request->getIsLivePreview())
             );
+            
+            $cacheKey = ArrayHelper::remove($config, 'cacheKey')
+                ?? implode(':', [
+                    'elementapi',
+                    Craft::$app->getSites()->getCurrentSite()->id,
+                    $this->request->getPathInfo(),
+                    $this->request->getQueryStringWithoutPath(),
+                ]);
 
             if ($cache) {
-                $cacheKey = ArrayHelper::remove($config, 'cacheKey')
-                    ?? implode(':', [
-                        'elementapi',
-                        Craft::$app->getSites()->getCurrentSite()->id,
-                        $this->request->getPathInfo(),
-                        $this->request->getQueryStringWithoutPath(),
-                    ]);
                 $cacheService = Craft::$app->getCache();
 
                 if (($cachedContent = $cacheService->get($cacheKey)) !== false) {


### PR DESCRIPTION
### Description

Thanks for accepting #145. After your cleanup I’m now unable to (easily) set a `cacheKey` and disable caching for dev environments.

This is the config I was using before

```php
'defaults' => static function() {
    $isDev = App::env('ENVIRONMENT') === 'dev';
    $request = Craft::$app->getRequest();

    return [
        'cache' => $isDev ? false : 'P1Y', // one year
        'cacheKey' => implode(':', [
            'elementapi',
            Craft::$app->getSites()->getCurrentSite()->id,
            $request->getPathInfo(),
            $request->getQueryStringWithoutPath(),
            $request->getHeaders()->get('X-API-Token'),
        ]),
    ];
},
```

Error message after updating to 2.8

> Setting unknown property: craft\\elementapi\\resources\\ElementResource::cacheKey