### PR TITLE
#158 Fix error for cached endpoints on preview

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -89,12 +89,12 @@ class DefaultController extends Controller
             $this->response->getHeaders()->setDefault('X-Robots-Tag', 'none');
 
             // Before anything else, check the cache
-            if (!($this->request->getIsPreview() || $this->request->getIsLivePreview())) {
-                $cache = ArrayHelper::remove($config, 'cache', true);
-            } else {
+            $cache = ArrayHelper::remove($config, 'cache', true);
+            if ($this->request->getIsPreview() || $this->request->getIsLivePreview()) {
+                // Ignore config & disable cache for live preview
                 $cache = false;
             }
-
+            
             $cacheKey = ArrayHelper::remove($config, 'cacheKey')
                 ?? implode(':', [
                     'elementapi',


### PR DESCRIPTION
Fix a server error occurring when cache was enabled and the element was being previewed

### Description
This fixed the server error "Setting unknown property: craft\elementapi\resources\ElementResource::cache" when trying to load an endpoint with cache enabled in the config and (live) preview mode being on.

The "cache"-key was being kept on the config object only in this use case, despite it not being used. Proposed solution will remove it from the $config array always, but still ignore/disable the cache setting if preview is enabled.

### Related issues
#158 
