### PR TITLE
disable route/response caching in devMode

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -10,6 +10,7 @@
 namespace craft\elementapi\controllers;
 
 use Craft;
+use craft\config\GeneralConfig;
 use craft\elementapi\DataEvent;
 use craft\elementapi\JsonFeedV1Serializer;
 use craft\elementapi\Plugin;
@@ -225,7 +226,7 @@ class DefaultController extends Controller
         if ($statusCode !== 200) {
             $cache = false;
         }
-        if ($cache) {
+        if ($cache && !GeneralConfig::instance()->devMode()) {
             if ($cache !== true) {
                 $expire = ConfigHelper::durationInSeconds($cache);
             } else {


### PR DESCRIPTION
Added option to suppress endpoint caching in devMode

### Description

Ability to forego the tedious activity of always having to purge caches while testing changes in the code.

### Related issues

