### PR TITLE
Fix error if no cache tags was registered

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -25,6 +25,7 @@ use League\Fractal\Serializer\SerializerAbstract;
 use ReflectionFunction;
 use yii\base\InvalidConfigException;
 use yii\base\UserException;
+use yii\caching\TagDependency;
 use yii\web\HttpException;
 use yii\web\JsonResponseFormatter;
 use yii\web\Response;
@@ -234,7 +235,14 @@ class DefaultController extends Controller
 
             /** @phpstan-ignore-next-line */
             [$dep, $maxDuration] = $elementsService->stopCollectingCacheInfo();
-            $dep->tags[] = 'element-api';
+            
+            if (is_null($dep)) {
+                $dep = new TagDependency([
+                    'tags' => ['element-api'],
+                ]);
+            } else {
+                $dep->tags[] = 'element-api';
+            }
 
             if ($maxDuration) {
                 if ($expire !== null) {


### PR DESCRIPTION
If no cache tags was registered, stopCollectingCacheInfo() returns [null, null]. If we try to assign another tag 'element-api' on it, we get the following error: [Error] Attempt to modify property "tags" on null

This patch solves the problem.

### Description



### Related issues

