### PR TITLE
bump fractal to ^0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Element API
 
+## Unreleased
+
+- Updated Fractal to 0.21. ([#202](https://github.com/craftcms/element-api/issues/202))
+
 ## 4.2.0 - 2025-01-20
 
 - Endpoint configs are now merged into the `defaults` array recursively, making it possible to specify default criteria params. ([#195](https://github.com/craftcms/element-api/issues/195))

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "prefer-stable": true,
   "require": {
     "craftcms/cms": "^4.3.0|^5.0.0-beta.1",
-    "league/fractal": "^0.20.1"
+    "league/fractal": "^0.21"
   },
   "require-dev": {
     "craftcms/ecs": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4f4d832d9f6c9825f5231a79efab836",
+    "content-hash": "4c274803bb27d1c9217510c97a6ba4b0",
     "packages": [
         {
             "name": "cebe/markdown",
@@ -2090,16 +2090,16 @@
         },
         {
             "name": "league/fractal",
-            "version": "0.20.1",
+            "version": "0.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/fractal.git",
-                "reference": "8b9d39b67624db9195c06f9c1ffd0355151eaf62"
+                "reference": "9e817358dc451dfdcf656d6757f0c04e92dea0e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/fractal/zipball/8b9d39b67624db9195c06f9c1ffd0355151eaf62",
-                "reference": "8b9d39b67624db9195c06f9c1ffd0355151eaf62",
+                "url": "https://api.github.com/repos/thephpleague/fractal/zipball/9e817358dc451dfdcf656d6757f0c04e92dea0e8",
+                "reference": "9e817358dc451dfdcf656d6757f0c04e92dea0e8",
                 "shasum": ""
             },
             "require": {
@@ -2107,19 +2107,19 @@
             },
             "require-dev": {
                 "doctrine/orm": "^2.5",
+                "friendsofphp/php-cs-fixer": "^3.91",
                 "illuminate/contracts": "~5.0",
+                "laminas/laminas-paginator": "~2.12",
                 "mockery/mockery": "^1.3",
-                "pagerfanta/pagerfanta": "~1.0.0",
+                "pagerfanta/pagerfanta": "~1.0.0|~4.0.0",
                 "phpstan/phpstan": "^1.4",
                 "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "~3.4",
-                "vimeo/psalm": "^4.22",
-                "zendframework/zend-paginator": "~2.3"
+                "vimeo/psalm": "^4.30"
             },
             "suggest": {
                 "illuminate/pagination": "The Illuminate Pagination component.",
-                "pagerfanta/pagerfanta": "Pagerfanta Paginator",
-                "zendframework/zend-paginator": "Zend Framework Paginator"
+                "laminas/laminas-paginator": "Laminas Framework Paginator",
+                "pagerfanta/pagerfanta": "Pagerfanta Paginator"
             },
             "type": "library",
             "extra": {
@@ -2154,9 +2154,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/fractal/issues",
-                "source": "https://github.com/thephpleague/fractal/tree/0.20.1"
+                "source": "https://github.com/thephpleague/fractal/tree/0.21"
             },
-            "time": "2022-04-11T12:47:17+00:00"
+            "time": "2025-12-08T21:14:52+00:00"
         },
         {
             "name": "mikehaertl/php-shellcommand",


### PR DESCRIPTION
### Description
Updates `league/fractal` dependency from `^0.20.1` to `^0.21`.

There’s one breaking change mentioned in the fractal’s changelog, but we don’t use the method it references, so all good.

The only other change worth keeping in mind is that `JsonApiSerilizer` will now omit empty attributes as opposed to returning an empty object (https://github.com/thephpleague/fractal/pull/578).


### Related issues
#202 
